### PR TITLE
fix: Add missing options to storage constructor

### DIFF
--- a/index.js
+++ b/index.js
@@ -61,7 +61,7 @@ class Hyperdrive extends Nanoresource {
       // TODO: Support mixed sparsity.
       sparse: this.sparse || this.sparseMetadata,
       extensions: opts.extensions
-    })
+    }, this)
 
     if (this.corestore !== storage) this.corestore.on('error', err => this.emit('error', err))
     if (opts.namespace) {

--- a/lib/storage.js
+++ b/lib/storage.js
@@ -1,12 +1,12 @@
 const raf = require('random-access-file')
 const Corestore = require('corestore')
 
-module.exports = function defaultCorestore (storage, opts) {
+module.exports = function defaultCorestore (storage, opts, drive) {
   if (isCorestore(storage)) return storage
   if (typeof storage === 'function') {
-    var factory = path => storage(path)
+    var factory = path => storage(path, opts, drive)
   } else if (typeof storage === 'string') {
-    factory = path => raf(storage + '/' + path)
+    factory = path => raf(storage + '/' + path, opts, drive)
   }
   return new Corestore(factory, opts)
 }


### PR DESCRIPTION
The README says:

> The `storage` parameter defines how the contents of the drive will be stored....
>  - `name`: the name of the file to be stored
>  - `opts`
>      - `key`: the [feed key](https://github.com/mafintosh/hypercore#feedkey) of the underlying Hypercore instance
>      - `discoveryKey`: the [discovery key](https://github.com/mafintosh/hypercore#feeddiscoverykey) of the underlying Hypercore instance
>  - `drive`: the current Hyperdrive instance


It wasn't clear to me if `opts` still has the feed key and discovery key, but I pass them along here anyway. If the README is out of date, I can update it too in this PR.

This feature /could be/(?) useful if you are creating a storage adapter that needs the drive/hypertrie, like files-as-files, although I haven't gone too far down that rabbithole yet.