### PR TITLE
allow content options as init argument (for use with custom encoding)

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,6 +54,7 @@ class Hyperdrive extends Nanoresource {
     this.sparse = opts.sparse !== false
     this.sparseMetadata = opts.sparseMetadata !== false
     this.subtype = opts.subtype || 'hyperdrive'
+    this.contentOpts = opts.contentOpts || {}
 
     this.promises = new HyperdrivePromises(this)
 

--- a/lib/content.js
+++ b/lib/content.js
@@ -6,7 +6,8 @@ function contentOptions (self) {
   return {
     sparse: self.sparse || self.latest,
     maxRequests: self.maxRequests,
-    storageCacheSize: self.contentStorageCacheSize
+    storageCacheSize: self.contentStorageCacheSize,
+    ...self.contentOpts
   }
 }
 


### PR DESCRIPTION
enable `contentOpts` as an argument, and merge with the `contentOptions` function. This brings kappa-drive up to date with the latest hyperdrive, let me know if this is acceptable!

following discussion here from a while back: https://github.com/hypercore-protocol/hyperdrive/pull/289