### PR TITLE
Use subEncoder for files sub

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,11 +194,11 @@ Returns a stream of all entries in the drive at paths prefixed with `folder`.
 
 Returns a stream of all subpaths of entries in drive stored at paths prefixed by `folder`.
 
-#### `const stream = await drive.entries([options])`
+#### `const stream = await drive.entries([range], [options])`
 
 Returns a read stream of entries in the drive.
 
-`options` are the same as the `options` to `Hyperbee().createReadStream(options)`.
+`range` and `options` are the same as the `range` and `options` in `Hyperbee().createReadStream(options)`.
 
 #### `const mirror = drive.mirror(out, [options])`
 

--- a/index.js
+++ b/index.js
@@ -99,8 +99,6 @@ module.exports = class Hyperdrive extends ReadyResource {
         await this.blobs.core.close()
       }
       await this.db.close()
-      // TODO:verify that the reason for this workaround is now taken away
-      // await this.files.close() // workaround to flush the batches for now. TODO: kill the sub!
     } catch (e) {
       safetyCatch(e)
     }

--- a/index.js
+++ b/index.js
@@ -277,14 +277,17 @@ module.exports = class Hyperdrive extends ReadyResource {
 
   diff (length, folder, opts = {}) {
     if (typeof folder === 'object' && folder && !opts) return this.diff(length, null, folder)
+
+    const range = {}
     if (folder) {
       if (folder.endsWith('/')) folder = folder.slice(0, -1)
       if (folder) folder = normalizePath(folder)
-      opts = { gt: folder + '/', lt: folder + '0', ...opts }
+      range.gt = folder + '/'
+      range.lt = folder + '0'
     }
 
     opts = { ...opts, keyEncoding: FILES_SUB }
-    return this.db.createDiffStream(length, opts)
+    return this.db.createDiffStream(length, range, opts)
   }
 
   async downloadDiff (length, folder, opts) {

--- a/index.js
+++ b/index.js
@@ -268,11 +268,8 @@ module.exports = class Hyperdrive extends ReadyResource {
 
     if (folder.endsWith('/')) folder = folder.slice(0, -1)
 
-    const encoder = new SubEncoder()
-    const files = encoder.sub('files', this.db.keyEncoding)
     const options = { map: (snap) => this._makeCheckout(snap) }
-
-    return this.db.watch({ gt: files.encode(folder + '/'), lt: files.encode(folder + '0') }, options)
+    return this.db.watch({ gt: FILES_SUB.encode(folder + '/'), lt: FILES_SUB.encode(folder + '0') }, options)
   }
 
   diff (length, folder, opts = {}) {

--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ const ReadyResource = require('ready-resource')
 const safetyCatch = require('safety-catch')
 
 const DB_KEY_ENCODING = 'utf-8'
-const FILES_SUB = (new SubEncoder()).sub('files', DB_KEY_ENCODING)
+const FILES_SUB = new SubEncoder('files', DB_KEY_ENCODING)
 
 module.exports = class Hyperdrive extends ReadyResource {
   constructor (corestore, key, opts = {}) {

--- a/index.js
+++ b/index.js
@@ -328,9 +328,11 @@ module.exports = class Hyperdrive extends ReadyResource {
     await Promise.allSettled(proms)
   }
 
-  entries (opts = {}) {
-    opts = { ...opts, keyEncoding: FILES_SUB }
-    return this.db.createReadStream(opts)
+  entries (range = {}, opts = {}) {
+    if (opts) opts.keyEncoding = FILES_SUB
+    else range.keyEncoding = FILES_SUB // backward compat
+
+    return this.db.createReadStream(range, opts)
   }
 
   async download (folder = '/', opts) {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "ready-resource": "^1.0.0",
     "safety-catch": "^1.0.2",
     "streamx": "^2.12.4",
-    "sub-encoder": "^2.1.0",
+    "sub-encoder": "^2.1.1",
     "unix-path-resolve": "^1.0.2"
   },
   "devDependencies": {

--- a/test.js
+++ b/test.js
@@ -730,6 +730,7 @@ test('drive.batch() & drive.flush()', async (t) => {
 })
 
 test('batch.list()', async (t) => {
+  t.plan(1)
   const { drive } = await testenv(t.teardown)
   const nil = b4a.from('nil')
   await drive.put('/x', nil)

--- a/test.js
+++ b/test.js
@@ -796,6 +796,18 @@ test('drive.close() on snapshots--does not close parent', async (t) => {
   t.alike(res, b4a.from('bar'))
 })
 
+test('drive.batch() on non-ready drive', async (t) => {
+  const drive = new Hyperdrive(new Corestore(RAM))
+  const batch = drive.batch()
+  await batch.put('/x', 'something')
+  await batch.flush()
+  t.ok(await drive.get('/x'))
+
+  await batch.close()
+  // TODO: uncomment when blobs session leaks fix is in
+  // t.is(batch.blobs.core.closed, true)
+})
+
 test('drive.close() for future checkout', async (t) => {
   const { drive } = await testenv(t.teardown)
   await drive.put('some', 'thing')

--- a/test.js
+++ b/test.js
@@ -485,6 +485,38 @@ test('drive.entries()', async (t) => {
   t.is(entries.size, 0)
 })
 
+test('drive.entries() with explicit range, no opts', async (t) => {
+  const { drive } = await testenv(t.teardown)
+
+  await drive.put('/aFile', 'here')
+  await drive.put('/bFile', 'later')
+  await drive.put('/zFile', 'last')
+
+  const expected = ['/bFile', '/zFile']
+  const observed = []
+  for await (const entry of drive.entries({ gt: '/b', lte: '/zzz' })) {
+    observed.push(entry.key)
+  }
+
+  t.alike(expected, expected)
+})
+
+test('drive.entries() with explicit range and opts', async (t) => {
+  const { drive } = await testenv(t.teardown)
+
+  await drive.put('/aFile', 'here')
+  await drive.put('/bFile', 'later')
+  await drive.put('/zFile', 'last')
+
+  const expected = ['/zFile', '/bFile']
+  const observed = []
+  for await (const entry of drive.entries({ gt: '/b', lte: '/zzz' }, { reverse: true })) {
+    observed.push(entry.key)
+  }
+
+  t.alike(observed, expected)
+})
+
 test('drive.list(folder, { recursive })', async (t) => {
   {
     const { drive, paths: { root } } = await testenv(t.teardown)


### PR DESCRIPTION
Original here: https://github.com/holepunchto/hyperdrive-next/pull/57 

Marked as draft because I'm not sure exactly which parts of the code related to batches were work-arounds and which were on purpose. Note in particular that I am now passing the blobs through as a parameter instead of loading it again from this.db in a batch, which enables me to use the _db arg to pass the batch and to get rid of the _files arg (I couldn't figure out why a batch needed to reload the blobs, but there might have been a reason).

There's also a TODO marked in the PR to verify something in the close logic, where we recently made a fix with comment 'workaround to flush the batches for now.' => I think that's no longer relevant, but sanity checking that before fully removing
