### PR TITLE
Fix checkout clear bug

### DIFF
--- a/index.js
+++ b/index.js
@@ -137,7 +137,11 @@ module.exports = class Hyperdrive extends ReadyResource {
   }
 
   async _open () {
-    if (this._checkout) return this._checkout.ready()
+    if (this._checkout) {
+      await this._checkout.ready()
+      await this.getBlobs()
+      return
+    }
 
     await this._openBlobsFromHeader({ wait: false })
 

--- a/index.js
+++ b/index.js
@@ -139,7 +139,7 @@ module.exports = class Hyperdrive extends ReadyResource {
   async _open () {
     if (this._checkout) {
       await this._checkout.ready()
-      await this.getBlobs()
+      this.blobs = this._checkout.blobs
       return
     }
 

--- a/test.js
+++ b/test.js
@@ -878,6 +878,28 @@ test('drive.clear(path) with diff', async (t) => {
   await b.close()
 })
 
+test('drive.clear(path) on a checkout', async (t) => {
+  const { drive } = await testenv(t.teardown)
+  await drive.put('/loc', 'hello world')
+
+  const entry = await drive.entry('/loc')
+  const initContent = await drive.blobs.get(entry.value.blob, { wait: false })
+  t.alike(initContent, b4a.from('hello world'))
+
+  const checkout = drive.checkout(drive.version)
+
+  const cleared = await checkout.clear('/loc')
+  t.is(cleared, null)
+
+  // Entry still exists (so file not deleted)
+  const nowEntry = await checkout.entry('/loc')
+  t.alike(nowEntry, entry)
+
+  // But the blob is removed from storage
+  const nowContent = await checkout.blobs.get(entry.value.blob, { wait: false })
+  t.is(nowContent, null)
+})
+
 test('drive.clearAll() with diff', async (t) => {
   const storage = createTmpDir(t)
 


### PR DESCRIPTION
Clearing on a checkout does not currently work, because `_open` on a checkout doesn't eagerly open the blobs (causing `clear` to short-circuit). Let me know if I'm misunderstanding the reasoning for that.

The first commit in this PR is the failing test, and the second is the fix.