### PR TITLE
Fix blobs session leak on batching

### DIFF
--- a/index.js
+++ b/index.js
@@ -91,7 +91,11 @@ module.exports = class Hyperdrive extends ReadyResource {
   }
 
   async _close () {
-    if (this._batching) return this.files.close()
+    if (this._batching) {
+      await this.blobs.core.close()
+      return this.files.close()
+    }
+
     try {
       if (this.blobs !== null && (this._checkout === null || this.blobs !== this._checkout.blobs)) {
         await this.blobs.core.close()

--- a/test.js
+++ b/test.js
@@ -727,6 +727,15 @@ test('drive.batch() & drive.flush()', async (t) => {
   await batch.put('/y', nil)
   await batch.flush()
   t.ok(await drive.get('/x'))
+
+  // No session leaks
+  await batch.close()
+  t.ok(batch.blobs.core.closed)
+
+  // Sanity check: nothing else closed
+  t.is(drive.blobs.core.closed, false)
+  t.is(drive.db.closed, false)
+  t.is(drive.files.core.closed, false)
 })
 
 test('batch.list()', async (t) => {


### PR DESCRIPTION
Currently a new blobs core session is created whenever a new batch is created, but they are never closed. This PR always closes the blobs core of a batch.