### PR TITLE
drive.download() does not work as expected

### DIFF
--- a/test.js
+++ b/test.js
@@ -679,6 +679,28 @@ test('drive.download(folder, [options])', async (t) => {
   t.is(count, _count + 1)
 })
 
+test.solo('drive.download()', async (t) => {
+  const store1 = new Corestore(RAM)
+  const store2 = new Corestore(RAM)
+  const drive1 = new Hyperdrive(store1)
+  await drive1.ready()
+  const drive2 = new Hyperdrive(store2, drive1.key)
+  await drive2.ready()
+
+  const nil = b4a.from('nil')
+
+  await drive1.put('/foo', nil)
+
+  const s = store1.replicate(true)
+  s.pipe(store2.replicate(false)).pipe(s)
+
+  // Must do this in order for this test to pass
+  // await drive2.db.core.update({ wait: true })
+  await drive2.download()
+
+  t.alike(await drive2.get('/foo'), nil)
+})
+
 test.skip('drive.downloadRange(dbRanges, blobRanges)', async (t) => {
   const { drive, swarm, mirror, corestore } = await testenv(t.teardown)
   swarm.on('connection', (conn) => corestore.replicate(conn))


### PR DESCRIPTION
Calling `await drive.download()` does not download the expected data if you do not wait for the drive to update first. Currently `drive.update({ wait: true })` does not work as expected either. This is possibly due to hyperbee read streams not being updated to account for the change in default behaviour of hypercore changing to updates being local only by default.

This PR adds a failing test, but I'm not sure if the fix belongs here or in hyperbee.