### PR TITLE
shallowReadStream: Use only entry prefix for directory keys

### DIFF
--- a/index.js
+++ b/index.js
@@ -540,6 +540,10 @@ function shallowReadStream (files, folder, keys) {
         return
       }
 
+      if (i !== -1) {
+        node = { key: node.key.slice(0, folder.length + i + 1)}
+      }
+
       prevName = name
       this.push(keys ? name : node)
       cb(null)


### PR DESCRIPTION
This change makes `drive.list(folder, { recursive: false })` return only the entry prefix key for directories.

Given that the root directory contains

```
/foo
/bar/baz
/bar/quux
```

Previously, `drive.list('/', { recursive: false })` returned

```
{
  seq: 42,
  key: '/foo',
  value: { ... }
}
{
  seq: 43,
  key: '/bar/baz',  // Expected key: '/bar'
  value: { ... }
}
```

Now, `drive.list('/', { recursive: false })` returns

```
{
  seq: 42,
  key: '/foo',
  value: { ... }
}
{
  key: '/bar',
}
```

Note that `seq` and `value` properties have been thrown away since they don't belong to the entry prefix.