### PR TITLE
Clean up truncate

### DIFF
--- a/index.js
+++ b/index.js
@@ -95,10 +95,16 @@ module.exports = class Hyperdrive extends ReadyResource {
   }
 
   async truncate (version, { blobs = -1 } = {}) {
+    if (!this.opened) await this.ready()
+
+    if (version > this.core.length) {
+      throw BAD_ARGUMENT('Bad truncation length')
+    }
+
     const blobsVersion = blobs === -1 ? await this.getBlobsLength(version) : blobs
     const bl = await this.getBlobs()
 
-    if (version > this.core.length || blobsVersion > bl.core.length) {
+    if (blobsVersion > bl.core.length) {
       throw BAD_ARGUMENT('Bad truncation length')
     }
 
@@ -107,7 +113,8 @@ module.exports = class Hyperdrive extends ReadyResource {
   }
 
   async getBlobsLength (checkout) {
-    await this.ready()
+    if (!this.opened) await this.ready()
+
     if (!checkout) checkout = this.version
 
     const c = this.db.checkout(checkout)

--- a/test.js
+++ b/test.js
@@ -1473,6 +1473,18 @@ test('truncate happy path', async t => {
   t.is(drive.blobs.core.fork, 1, 'sanity check on blobs fork')
 })
 
+test('truncate throws when truncating future version)', async t => {
+  const corestore = new Corestore(RAM.reusable())
+  const drive = new Hyperdrive(corestore)
+
+  await drive.put('./file', 'here')
+  await t.exception(
+    () => drive.truncate(10),
+    /Bad truncation length/,
+    'throws when truncating the future'
+  )
+})
+
 async function testenv (teardown) {
   const corestore = new Corestore(RAM)
   await corestore.ready()


### PR DESCRIPTION
- Ensure the drive is ready
- Throw when truncating future version (previous behaviour was to hang on `getBlobsLength`, before reaching the bad-argument check) 
