### PR TITLE
add get db key as a static method

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,6 +44,14 @@ module.exports = class Hyperdrive extends ReadyResource {
     return this.entries()[Symbol.asyncIterator]()
   }
 
+  static async getDriveKey (corestore) {
+    const core = makeBee(undefined, corestore)
+    await core.ready()
+    const key = core.key
+    await core.close()
+    return key
+  }
+
   static getContentKey (m, key) {
     if (m instanceof Hypercore) {
       if (m.core.compat) return null
@@ -634,7 +642,7 @@ function shallowReadStream (files, folder, keys) {
   })
 }
 
-function makeBee (key, corestore, opts) {
+function makeBee (key, corestore, opts = {}) {
   const name = key ? undefined : 'db'
   const core = corestore.get({ key, name, exclusive: true, onwait: opts.onwait, encryptionKey: opts.encryptionKey, compat: opts.compat, active: opts.active })
 

--- a/test.js
+++ b/test.js
@@ -1485,6 +1485,22 @@ test('truncate throws when truncating future version)', async t => {
   )
 })
 
+test('get drive key without using the constructor', async (t) => {
+  t.plan(1)
+  const corestore = new Corestore(RAM.reusable())
+  const key = await Hyperdrive.getDriveKey(corestore.session())
+  const drive = new Hyperdrive(corestore.session())
+
+  t.teardown(() => {
+    corestore.close()
+    drive.close()
+  })
+
+  await drive.ready()
+
+  t.is(key.toString('hex'), drive.key.toString('hex'))
+})
+
 async function testenv (teardown) {
   const corestore = new Corestore(RAM)
   await corestore.ready()


### PR DESCRIPTION
This PR adds a static method that returns the primary key of a Hyperdrive for a corestore instance. 