### PR TITLE
Add `drive.rename(oldPath, newPath)`

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,18 +31,20 @@ console.log(entry) // => { seq, key, value: { executable, linkname, blob, metada
 
 await drive.del('/images/old-logo.png')
 
+await drive.rename('/images/blob.txt', '/images/example.txt')
+
 await drive.symlink('/images/logo.shortcut', '/images/logo.png')
 
 for await (const file of drive.list('/images')) {
   console.log('list', file) // => { key, value }
 }
 
-const rs = drive.createReadStream('/blob.txt')
+const rs = drive.createReadStream('/images/example.txt')
 for await (const chunk of rs) {
   console.log('rs', chunk) // => <Buffer ..>
 }
 
-const ws = drive.createWriteStream('/blob.txt')
+const ws = drive.createWriteStream('/images/example.txt')
 ws.write('new example')
 ws.end()
 ws.once('close', () => console.log('file saved'))
@@ -203,6 +205,10 @@ A `blobs: <length>` option can be passed in if you know the corresponding blobs 
 #### `await drive.purge()`
 
 Purge both cores (db and blobs) from your storage, completely removing all the drive's data.
+
+#### `await drive.rename(oldPath, newPath, [options])`
+
+Renames the `oldPath` entry in the drive to be `newPath`. `options` are the same as in `get`.
 
 #### `await drive.symlink(path, linkname)`
 

--- a/index.js
+++ b/index.js
@@ -358,6 +358,12 @@ module.exports = class Hyperdrive extends ReadyResource {
     await Promise.all(proms)
   }
 
+  async rename (oldPath, newPath, opts) {
+    const existingEntry = await this.entry(oldPath, opts)
+    await this.db.del(std(oldPath, false), { keyEncoding })
+    return this.db.put(std(newPath, false), existingEntry.value, { keyEncoding })
+  }
+
   async symlink (name, dst, { metadata = null } = {}) {
     return this.db.put(std(name, false), { executable: false, linkname: dst, blob: null, metadata }, { keyEncoding })
   }

--- a/test.js
+++ b/test.js
@@ -185,6 +185,17 @@ test('drive.del() deletes entry at path', async (t) => {
   t.is(entry, null)
 })
 
+test('drive.rename(oldPath, newPath) updates the entry at <oldPath> to use <newPath> as a key', async (t) => {
+  const { drive } = await testenv(t.teardown)
+  const buf = fs.readFileSync(__filename)
+  await drive.put(__filename, buf)
+  await drive.rename(__filename, 'new-file')
+  const resultOld = await drive.get(__filename)
+  t.is(resultOld, null)
+  const resultNew = await drive.get('new-file')
+  t.is(b4a.compare(buf, resultNew), 0)
+})
+
 test('drive.symlink(from, to) updates the entry at <from> to include a reference for <to>', async (t) => {
   const { drive } = await testenv(t.teardown)
   const buf = fs.readFileSync(__filename)


### PR DESCRIPTION
Only updates the file entry in the hyperbee.

This PR was inspired by someone wanting to rename the file without having to re-append the blobstore entry.