### PR TITLE
Fix flaky test: ensure it uses the correct length

### DIFF
--- a/test.js
+++ b/test.js
@@ -1375,7 +1375,7 @@ test('drive.get(key, { wait }) with entry but no blob', async (t) => {
   await drive.put('/file.txt', b4a.from('hi'))
   await mirror.drive.getBlobs()
 
-  const entry = await mirror.drive.entry('/file.txt')
+  const entry = await mirror.drive.checkout(2).entry('/file.txt')
   t.ok(entry)
   t.ok(entry.value.blob)
 

--- a/test.js
+++ b/test.js
@@ -1375,9 +1375,11 @@ test('drive.get(key, { wait }) with entry but no blob', async (t) => {
   await drive.put('/file.txt', b4a.from('hi'))
   await mirror.drive.getBlobs()
 
-  const entry = await mirror.drive.checkout(2).entry('/file.txt')
+  const mirrorCheckout = mirror.drive.checkout(2)
+  const entry = await mirrorCheckout.entry('/file.txt')
   t.ok(entry)
   t.ok(entry.value.blob)
+  await mirrorCheckout.close()
 
   await swarm.destroy()
   await drive.close()


### PR DESCRIPTION
Without the checkout, occasionally (~1/200 runs) the `entry` call runs on a drive with version 1 instead of 2, causing it to return null.